### PR TITLE
Add support for objects with overloaded __isset

### DIFF
--- a/src/Dust/Evaluate/Context.php
+++ b/src/Dust/Evaluate/Context.php
@@ -100,8 +100,8 @@ class Context {
     
     public function findInObject($key, $parent) {
         if (is_object($parent) && !is_numeric($key)) {
-            //prop or method
-            if (array_key_exists($key, $parent)) {
+            //prop || overloaded prop or method
+            if (array_key_exists($key, $parent) || ( !($parent instanceof \Closure) && isset($parent->{$key})) ) {
                 return $parent->{$key};
             } elseif (method_exists($parent, $key)) {
                 return (new \ReflectionMethod($parent, $key))->getClosure($parent);

--- a/tests/Dust/StandardTest.php
+++ b/tests/Dust/StandardTest.php
@@ -77,5 +77,9 @@ class StandardTest extends DustTestBase {
         //test some things (kinda taken from PHP manual)
         $this->assertTemplate('bcdef,bcd,abcd,abcdef,bc', '{@substr str="abcdef" begin=1 /},' . '{@substr str="abcdef" begin=1 len=3 /},' . '{@substr str="abcdef" len=4 /},' . '{@substr str="abcdef" len=8 /},' . '{@substr str="abcdef" begin=1 end=3 /}', (object)[]);
     }
+
+    public function testIssetAccess() {
+        $this->assertTemplate('Farce,slapstick,musical comedy', '{#genres}{.}{@sep},{/sep}{/genres}', new StoogesContext());
+    }
     
 }

--- a/tests/Dust/StoogesContext.php
+++ b/tests/Dust/StoogesContext.php
@@ -7,5 +7,21 @@ class StoogesContext {
     public function names() {
         return [new StoogeName('Larry'), new StoogeName('Curly'), new StoogeName('Moe')];
     }
-    
+
+    public function __isset($name)
+    {
+        if($name === 'genres')
+        {
+            return true;
+        }
+    }
+
+    public function __get($key)
+    {
+        if($key === 'genres')
+        {
+            return ['Farce', 'slapstick', 'musical comedy'];
+        }
+    }
+
 }


### PR DESCRIPTION
In my case, my class overloads __isset and has a method, which when referenced as a property uses __get to resolve. I believe this covers any cases where a class overloads __isset and __get to resolve a property.